### PR TITLE
patch: k6 testrun arguments

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: datawindtunnel/plantd-controller
-  newTag: test3
+  newName: ghcr.io/carnegiemellon-plantd/plantd-controller
+  newTag: test

--- a/pkg/loadgen/loadgen.go
+++ b/pkg/loadgen/loadgen.go
@@ -2,6 +2,7 @@ package loadgen
 
 import (
 	"encoding/json"
+	"fmt"
 
 	windtunnelv1alpha1 "github.com/CarnegieMellon-PlantD/PlantD-operator/api/v1alpha1"
 	"github.com/CarnegieMellon-PlantD/PlantD-operator/pkg/config"
@@ -20,7 +21,7 @@ func CreateTestRunManifest(name string, namespace string) *k6v1alpha1.K6 {
 		},
 		Spec: k6v1alpha1.K6Spec{
 			Parallelism: 1,
-			Arguments:   config.GetString("k6.arguments"),
+			Arguments:   config.GetString("k6.arguments") + fmt.Sprintf(" --tag experiment=%s/%s", namespace, name),
 			Runner: k6v1alpha1.Pod{
 				Env: []corev1.EnvVar{
 					{


### PR DESCRIPTION
### Issue

* The metrics from K6 cannot be distinguished per experiment.

### Solution

* Add a tag: experiment=`namespace/name`