### PR TITLE
Fix/out cluster service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+test

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
-- manager.yaml
+  - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
-  newName: ghcr.io/carnegiemellon-plantd/plantd-controller
-  newTag: fix
+  - name: controller
+    newName: ghcr.io/carnegiemellon-plantd/plantd-controller
+    newTag: latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/carnegiemellon-plantd/plantd-controller
-  newTag: latest
+  newTag: fix

--- a/config/plantd/config.yaml
+++ b/config/plantd/config.yaml
@@ -12,9 +12,9 @@ plantdCore:
   serviceAccountName: plantd-operator-controller-manager
   kubeProxy:
     image: ghcr.io/carnegiemellon-plantd/plantd-proxy:latest
-    label: 
+    label:
       app: plantd-proxy
-    selector: 
+    selector:
       key: app
       value: plantd-proxy
     containerName: plantd-proxy
@@ -25,9 +25,9 @@ plantdCore:
     targetPort: 5000
   studio:
     image: ghcr.io/carnegiemellon-plantd/plantd-studio:latest
-    label: 
+    label:
       app: plantd-studio
-    selector: 
+    selector:
       key: app
       value: plantd-studio
     containerName: plantd-studio
@@ -210,7 +210,7 @@ k6:
 monitor:
   metricsService:
     labels:
-      key: plantd-pipeline
+      key: plantd-monitoring
   serviceMonitor:
     labels:
       component: plantd-metrics-endpoint

--- a/internal/controller/pipeline_controller.go
+++ b/internal/controller/pipeline_controller.go
@@ -186,14 +186,10 @@ func (r *PipelineReconciler) Initialize(ctx context.Context, pipeline *windtunne
 	return nil
 }
 
-func GetMetricsServiceName(pipelineName string) string {
-	return pipelineName + "-plantd-metrics"
-}
-
 func (r *PipelineReconciler) InitializeExp(ctx context.Context, pipeline *windtunnelv1alpha1.Pipeline) error {
 	log := log.FromContext(ctx)
 	// Get the metrics service
-	serviceName := types.NamespacedName{Namespace: pipeline.Namespace, Name: GetMetricsServiceName(pipeline.Name)}
+	serviceName := types.NamespacedName{Namespace: pipeline.Namespace, Name: utils.GetMetricsServiceName(pipeline.Name)}
 	if pipeline.Spec.InCluster {
 		serviceName = types.NamespacedName{Namespace: pipeline.Spec.MetricsEndpoint.ServiceRef.Namespace, Name: pipeline.Spec.MetricsEndpoint.ServiceRef.Name}
 	}
@@ -233,8 +229,7 @@ func (r *PipelineReconciler) CreateService(ctx context.Context, pipeline *windtu
 	log := log.FromContext(ctx)
 	// Create externalName service and endpoint for pipeline endpoints.
 	for _, endpoint := range pipeline.Spec.PipelineEndpoints {
-		name := pipeline.Name + "-" + endpoint.Name
-		serivce, endpoints, err := monitor.CreateExternalNameService(name, pipeline.Namespace, &endpoint)
+		serivce, endpoints, err := monitor.CreateExternalNameService(pipeline.Namespace, pipeline.Name, &endpoint)
 		if err != nil {
 			log.Error(err, "Cannot create service manifests for outside-cluster Pipeline")
 			return err
@@ -256,8 +251,7 @@ func (r *PipelineReconciler) CreateService(ctx context.Context, pipeline *windtu
 	}
 
 	// Create externalName service and endpoint for the metrics endpoint.
-	name := GetMetricsServiceName(pipeline.Name)
-	serivce, endpoints, err := monitor.CreateExternalNameService(name, pipeline.Namespace, &pipeline.Spec.MetricsEndpoint)
+	serivce, endpoints, err := monitor.CreateExternalNameService(pipeline.Namespace, pipeline.Name, &pipeline.Spec.MetricsEndpoint)
 	if err != nil {
 		log.Error(err, "Cannot create service manifests for outside-cluster Pipeline")
 		return err

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -64,7 +64,8 @@ func CreateServiceMonitor(pipeline *windtunnelv1alpha1.Pipeline) (*monitoringv1.
 	}, nil
 }
 
-func CreateExternalNameService(name string, namespace string, endpoint *windtunnelv1alpha1.Endpoint) (*corev1.Service, *corev1.Endpoints, error) {
+func CreateExternalNameService(namespace, pipelineName string, endpoint *windtunnelv1alpha1.Endpoint) (*corev1.Service, *corev1.Endpoints, error) {
+	name := utils.GetPipelineEndpointServiceName(pipelineName, endpoint.Name)
 	hostname, err := utils.GetHostname(endpoint.HTTP.URL)
 	if err != nil {
 		return nil, nil, err
@@ -87,8 +88,9 @@ func CreateExternalNameService(name string, namespace string, endpoint *windtunn
 	label := pipelineLabels
 	// Metrics Endpoint should not have an endpoint name
 	if portName == "" {
+		name = utils.GetMetricsServiceName(pipelineName)
 		portName = metricsPortName
-		label = map[string]string{metricsLabelKey: fmt.Sprintf("%s-%s", namespace, name)}
+		label = map[string]string{metricsLabelKey: fmt.Sprintf("%s-%s", namespace, pipelineName)}
 	}
 
 	service := &corev1.Service{

--- a/pkg/utils/healthcheck.go
+++ b/pkg/utils/healthcheck.go
@@ -15,7 +15,7 @@ const (
 func GetHostname(serviceURL string) (string, error) {
 	u, err := url.Parse(serviceURL)
 	if err != nil {
-		return "", fmt.Errorf("Error parsing URL: %v\n", err)
+		return "", fmt.Errorf("error parsing URL: %v", err)
 	}
 	return u.Hostname(), nil
 }
@@ -23,7 +23,7 @@ func GetHostname(serviceURL string) (string, error) {
 func GetPort(serviceURL string) (int32, error) {
 	u, err := url.Parse(serviceURL)
 	if err != nil {
-		return -1, fmt.Errorf("Error parsing URL: %v\n", err)
+		return -1, fmt.Errorf("error parsing URL: %v", err)
 	}
 	if sPort := u.Port(); sPort != "" {
 		port, err := strconv.Atoi(sPort)
@@ -38,7 +38,7 @@ func GetPort(serviceURL string) (int32, error) {
 	case "https":
 		return 443, nil
 	default:
-		return -1, fmt.Errorf("Cannot get the default port of scheme %s", u.Scheme)
+		return -1, fmt.Errorf("cannot get the default port of scheme %s", u.Scheme)
 	}
 }
 
@@ -64,7 +64,7 @@ func CheckHTTPHealth(url string) (bool, error) {
 func GetHTTPPath(metricsURL string) (string, error) {
 	u, err := url.Parse(metricsURL)
 	if err != nil {
-		return "", fmt.Errorf("Error parsing URL: %v\n", err)
+		return "", fmt.Errorf("error parsing URL: %v", err)
 	}
 	return u.Path, nil
 }

--- a/pkg/utils/name.go
+++ b/pkg/utils/name.go
@@ -25,3 +25,11 @@ func GetNamespacedName(obj client.Object) string {
 func GetTestRunName(expName string, endpointName string) string {
 	return fmt.Sprintf("%s-%s", expName, endpointName)
 }
+
+func GetMetricsServiceName(pipelineName string) string {
+	return pipelineName + "-plantd-metrics"
+}
+
+func GetPipelineEndpointServiceName(pipelineName string, endpointName string) string {
+	return fmt.Sprintf("%s-%s", pipelineName, endpointName)
+}


### PR DESCRIPTION
### Issue

* Out-cluster pipeline's label of the metrics endpoint service does not match to the serviceMonitor's labelSelector.

### Solution

* Fix the label of the metrics endpoint service to `plantd-monitoring:<NAMESPACE>-<PIPELINE_NAME>`.