### PR TITLE
fix: set experiment controller owns k6

### DIFF
--- a/internal/controller/experiment_controller.go
+++ b/internal/controller/experiment_controller.go
@@ -574,5 +574,6 @@ func (r *ExperimentReconciler) UpdatePipeline(ctx context.Context, pipeline *win
 func (r *ExperimentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&windtunnelv1alpha1.Experiment{}).
+		Owns(&k6v1alpha1.K6{}).
 		Complete(r)
 }


### PR DESCRIPTION
### Issue

* The status of experiment object won't go to complete when the load generator finished.

### Solution

* Let experiment controller watch the k6 objects.