### PR TITLE
Thanos querier changes

### DIFF
--- a/config/crd/bases/windtunnel.plantd.org_plantdcores.yaml
+++ b/config/crd/bases/windtunnel.plantd.org_plantdcores.yaml
@@ -327,8 +327,6 @@ spec:
               thanosStatus:
                 description: Thanos status
                 type: string
-            required:
-            - thanosStatus
             type: object
         type: object
     served: true

--- a/config/plantd/config.yaml
+++ b/config/plantd/config.yaml
@@ -71,7 +71,19 @@ plantDCore:
       replicas: 1
       httpPort: 9090
       grpcPort: 10901
-      storeUrl: thanos-sidecar-grpc.plantd-operator-system.svc.cluster.local:10901
+      url: thanos-sidecar-grpc.plantd-operator-system.svc.cluster.local:10901
+    thanosStore:
+      name: thanos-store
+      serviceName: thanos-store-grpc
+      labels:
+        app: thanos-store
+      image: quay.io/thanos/thanos:v0.34.0
+      replicas: 1
+      volumeSize: 1Gi
+      dataDir: /thanos-data
+      httpPort: 10902
+      grpcPort: 10901
+      url: thanos-store-grpc.plantd-operator-system.svc.cluster.local:10901
     thanosSidecarService:
       portName: grpc
       port: 10901
@@ -261,6 +273,7 @@ database:
   prometheus:
     # Ensure Prometheus service name, namespace, and port are correct
     url: http://prometheus-service.plantd-operator-system.svc.cluster.local:9090
+    thanosUrl: http://thanos-querier.plantd-operator-system.svc.cluster.local:9090
   redis:
     # Ensure Redis service name, namespace, and port are correct
     host: redis-service.plantd-operator-system.svc.cluster.local

--- a/pkg/proxy/query.go
+++ b/pkg/proxy/query.go
@@ -22,7 +22,7 @@ var (
 )
 
 func init() {
-	promUrl = config.GetString("database.prometheus.url")
+	promUrl = config.GetString("database.prometheus.thanosUrl")
 	redisAddr = fmt.Sprintf("%s:%d", config.GetString("database.redis.host"), config.GetInt("database.redis.port"))
 }
 


### PR DESCRIPTION
- Add Thanos store Statefulset and service (To query S3)
- Make Thanos querier deployment default
- Make Thanos sidecar push to S3 optional
- Change prometheus endpoint in proxy to thanos-querier endpoint